### PR TITLE
fix: update droplet image

### DIFF
--- a/nixops_digitalocean/backends/droplet.py
+++ b/nixops_digitalocean/backends/droplet.py
@@ -211,7 +211,7 @@ class DropletState(MachineState[DropletDefinition]):
             region=defn.region,
             ipv6=defn.enable_ipv6,
             ssh_keys=[ssh_key.public_key],
-            image="ubuntu-16-04-x64",  # only for lustration
+            image="ubuntu-20-04-x64",  # only for lustration
             size_slug=defn.size,
         )
 


### PR DESCRIPTION
Currently, the droplet image is set to 16.04  which no longer seems to be supported.

<img width="241" alt="CleanShot 2022-10-06 at 10 13 10@2x" src="https://user-images.githubusercontent.com/8011761/194240407-1478e54b-eb49-4a23-b34e-2a0581e9a62a.png">

resulting in an error
<img width="1110" alt="CleanShot 2022-10-06 at 10 13 43@2x" src="https://user-images.githubusercontent.com/8011761/194240698-5bbb54e3-f7e7-461e-b3b4-3aefde1b802d.png">
when attempting to create an image.

This PR attempts to upgrade the image to another version which also [seems to be compatible with lustration](https://github.com/elitak/nixos-infect) 

Ideal case would be that we convert to a variable which users can set but this would be a fast quick fix.
